### PR TITLE
Fix '/bin/bash^M: bad interpreter: No such file or directory' for bas…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ COPY wait-for-grid.sh /code/wait-for-grid.sh
 COPY run.py /code/run.py
 COPY runner.sh /code/runner.sh
 WORKDIR /code
+RUN sed -i -e 's/\r$//' wait-for-grid.sh
+RUN sed -i -e 's/\r$//' runner.sh
 CMD ["./wait-for-grid.sh", "./runner.sh"]

--- a/worker-prometheus/Dockerfile
+++ b/worker-prometheus/Dockerfile
@@ -8,4 +8,6 @@ COPY wait-for-grid.sh /code/wait-for-grid.sh
 COPY run.py /code/run.py
 COPY runner.sh /code/runner.sh
 WORKDIR /code
+RUN sed -i -e 's/\r$//' wait-for-grid.sh
+RUN sed -i -e 's/\r$//' runner.sh
 CMD ["./wait-for-grid.sh", "./runner.sh"]


### PR DESCRIPTION
Fix '/bin/bash^M: bad interpreter: No such file or directory' for bash scripts when docker compose up on Windows OS